### PR TITLE
(MODULES-10815) Add Slack notification job

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -56,3 +56,14 @@ jobs:
 
       - name: Run unit tests
         run: bundle exec rake parallel_spec
+
+  notify-via-slack:
+    name: Notify workflow conclusion via Slack
+    if: ${{ always() }}
+    needs: daily_unit_tests_with_nightly_puppet_gem
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: luchihoratiu/notify-via-slack@main
+        with:
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This commit adds a job to the `[Daily] Unit Tests with nightly Puppet
gem` workflow that notifies us the conclusion of it via Slack.