### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ end
 
 group :release do
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
-  gem "pdk",                                                                     platforms: [:ruby]
+  gem "pdk", '~> 2.0',                                                           platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -12,78 +12,43 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "CentOS"
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "OracleLinux"
     },
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "RedHat"
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "Scientific"
     },
     {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8"
-      ]
+      "operatingsystem": "Debian"
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
+      "operatingsystem": "Ubuntu"
     },
     {
-      "operatingsystem": "windows",
-      "operatingsystemrelease": [
-        "2008 R2",
-        "2012 R2",
-        "10"
-      ]
+      "operatingsystem": "windows"
     },
     {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "25"
-      ]
+      "operatingsystem": "Fedora"
     },
     {
-      "operatingsystem": "Darwin",
-      "operatingsystemrelease": [
-        "16"
-      ]
+      "operatingsystem": "Darwin"
     },
     {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "12"
-      ]
+      "operatingsystem": "SLES"
     },
     {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
+      "operatingsystem": "Solaris"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",

--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -9,7 +9,6 @@ module PuppetSpec::Files
   def self.cleanup
     until @global_tempfiles.empty?
       path = @global_tempfiles.pop
-      Dir.unstub(:entries)
       FileUtils.rm_rf path, secure: true
     end
   end

--- a/spec/shared_behaviours/all_parsedfile_providers.rb
+++ b/spec/shared_behaviours/all_parsedfile_providers.rb
@@ -5,7 +5,7 @@ shared_examples_for 'all parsedfile providers' do |provider, *files|
 
   files.flatten.each do |file|
     it "should rewrite #{file} reasonably unchanged" do
-      provider.stubs(:default_target).returns(file)
+      allow(provider).to receive(:default_target).and_return(file)
       provider.prefetch
 
       text = provider.to_file(provider.target_records(file))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ default_facts.each do |fact, value|
 end
 
 RSpec.configure do |c|
+  c.mock_with :rspec
   c.default_facts = default_facts
   c.before :each do
     # set to strictest setting for testing

--- a/spec/unit/provider/host/parsed_spec.rb
+++ b/spec/unit/provider/host/parsed_spec.rb
@@ -29,10 +29,10 @@ describe Puppet::Type.type(:host).provider(:parsed) do
   end
 
   def genhost(host)
-    provider.stubs(:filetype).returns(Puppet::Util::FileType::FileTypeRam)
-    File.stubs(:chown)
-    File.stubs(:chmod)
-    Puppet::Util::SUIDManager.stubs(:asuser).yields
+    allow(provider).to receive(:filetype).and_return(Puppet::Util::FileType::FileTypeRam)
+    allow(File).to receive(:chown)
+    allow(File).to receive(:chmod)
+    allow(Puppet::Util::SUIDManager).to receive(:asuser).and_yield
     host.flush
     provider.target_object(hostfile).read
   end

--- a/spec/unit/type/host_spec.rb
+++ b/spec/unit/type/host_spec.rb
@@ -4,7 +4,7 @@ FakeHostProvider = Struct.new(:ip, :host_aliases, :comment)
 
 describe Puppet::Type.type(:host) do
   let(:provider) { FakeHostProvider.new }
-  let(:resource) { stub('resource', resource: nil, provider: provider) }
+  let(:resource) { instance_double('Puppet::Type::Host', provider: provider) }
 
   it 'has :name be its namevar' do
     expect(described_class.key_attributes).to eq([:name])
@@ -645,7 +645,7 @@ describe Puppet::Type.type(:host) do
 
     it 'alsoes use the specified delimiter for joining' do
       host_aliases = described_class.attrclass(:host_aliases).new(resource: resource, should: ['foo', 'bar'])
-      host_aliases.stubs(:delimiter).returns "\t"
+      allow(host_aliases).to receive(:delimiter).and_return "\t"
       host_aliases.sync
 
       expect(provider.host_aliases).to eq("foo\tbar")


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent platform, it should be enough to specify the supported OS, without specific versions. It is assumed that for each OS in metadata.json, the versions supported are the same as what the agent itself supports.