### PR TITLE
Specify correct supported puppet version, 8.x only

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -60,7 +60,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.5.1",


### PR DESCRIPTION
Moving to pdk template 3.5.1 broke ruby 2.7 support, and by extension puppet 7.x.